### PR TITLE
Handle back press to hide ShoppingList inputs

### DIFF
--- a/app/ShoppingList.tsx
+++ b/app/ShoppingList.tsx
@@ -12,6 +12,7 @@ import {
   LayoutAnimation,
   Platform,
   UIManager,
+  BackHandler,
 } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
 import { Audio } from "expo-av";
@@ -44,6 +45,23 @@ const ShoppingList: React.FC = () => {
   const [formHeight, setFormHeight] = useState(0);
   const rainbowAnim = useRef(new Animated.Value(0)).current;
   const flatListRef = useRef<FlatList>(null);
+
+  useEffect(() => {
+    const onBackPress = () => {
+      if (isFormVisible) {
+        setIsFormVisible(false);
+        return true;
+      }
+      return false;
+    };
+
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      onBackPress
+    );
+
+    return () => subscription.remove();
+  }, [isFormVisible]);
 
   useEffect(() => {
     // Enable LayoutAnimation on Android


### PR DESCRIPTION
## Summary
- intercept hardware back events in ShoppingList
- hide inputs when back button pressed while inputs visible

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fdf779938832f82e02c1d3c15c8cd