### PR TITLE
Add AI model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The shopping list integrates with Google Gemini via the `@google/genai` SDK. You
 
 - Add, edit and remove shopping or wishlist items.
 - Voice commands for the shopping list using Gemini.
+- Choose between different AI models via the new configuration menu.
 - Local data stored with `AsyncStorage` so your lists persist between sessions.
 - Optional **LLM Chat** screen for talking to the model.
 - Works on Android, iOS and the web through Expo.
@@ -31,6 +32,7 @@ The shopping list integrates with Google Gemini via the `@google/genai` SDK. You
    ```bash
    npx expo start
    ```
+5. Use the settings button in the app header to choose between the available AI models.
 
 ## Running tests
 

--- a/app/LLMChat.tsx
+++ b/app/LLMChat.tsx
@@ -10,7 +10,11 @@ import {
 import { API_KEY } from "../config";
 import { GoogleGenAI } from "@google/genai";
 
-const LLMChat: React.FC = () => {
+interface LLMChatProps {
+  selectedModel: string;
+}
+
+const LLMChat: React.FC<LLMChatProps> = ({ selectedModel }) => {
   const [messages, setMessages] = useState<
     { role: "user" | "assistant"; content: string }[]
   >([]);
@@ -32,7 +36,7 @@ const LLMChat: React.FC = () => {
       const genAI = new GoogleGenAI({ apiKey: API_KEY });
 
       const result = await genAI.models.generateContent({
-        model: "gemini-2.5-flash-lite-preview-06-17",
+        model: selectedModel,
         contents: [
           ...messages.map((m) => ({
             role: m.role,

--- a/app/ModelSelector.tsx
+++ b/app/ModelSelector.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { MaterialIcons } from '@expo/vector-icons';
+
+interface ModelSelectorProps {
+  visible: boolean;
+  onClose: () => void;
+  selectedModel: string;
+  onSelect: (model: string) => void;
+}
+
+const MODELS = [
+  { label: 'Gemini 2.5 Flash Lite', value: 'gemini-2.5-flash-lite' },
+  { label: 'Gemini 2.5 Flash', value: 'gemini-2.5-flash' },
+  { label: 'Gemma 3n E4b IT', value: 'gemma-3n-e4b-it' },
+];
+
+const ModelSelector: React.FC<ModelSelectorProps> = ({
+  visible,
+  onClose,
+  selectedModel,
+  onSelect,
+}) => {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.title}>Select AI Model</Text>
+          {MODELS.map((m) => (
+            <TouchableOpacity
+              key={m.value}
+              style={[styles.option, selectedModel === m.value && styles.selectedOption]}
+              onPress={() => onSelect(m.value)}
+            >
+              <Text style={styles.optionText}>{m.label}</Text>
+              {selectedModel === m.value && (
+                <MaterialIcons name="check" size={24} color="#4CAF50" />
+              )}
+            </TouchableOpacity>
+          ))}
+          <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+            <Text style={styles.closeText}>Close</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    width: '80%',
+    backgroundColor: '#242424',
+    borderRadius: 10,
+    padding: 20,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#fff',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  option: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 10,
+  },
+  selectedOption: {
+    backgroundColor: '#333',
+    borderRadius: 6,
+  },
+  optionText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  closeButton: {
+    marginTop: 10,
+    backgroundColor: '#1976D2',
+    padding: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  closeText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});
+
+export default ModelSelector;

--- a/app/ModelSelector.tsx
+++ b/app/ModelSelector.tsx
@@ -10,9 +10,12 @@ interface ModelSelectorProps {
 }
 
 const MODELS = [
-  { label: 'Gemini 2.5 Flash Lite', value: 'gemini-2.5-flash-lite' },
-  { label: 'Gemini 2.5 Flash', value: 'gemini-2.5-flash' },
-  { label: 'Gemma 3n E4b IT', value: 'gemma-3n-e4b-it' },
+  { label: "Gemini 2.5 Flash", value: "gemini-2.5-flash" },
+  { label: "Gemini 2.5 Flash Lite", value: "gemini-2.5-flash-lite" },
+  { label: "Gemini 2.0 Flash", value: "gemini-2.0-flash" },
+  { label: "Gemini 2.0 Flash Lite", value: "gemini-2.0-flash-lite" },
+  { label: "Gemma 3 12B", value: "gemma-3-12b-it" },
+  { label: "Gemma 3 27B", value: "gemma-3-27b-it" },
 ];
 
 const ModelSelector: React.FC<ModelSelectorProps> = ({

--- a/app/ShoppingList.tsx
+++ b/app/ShoppingList.tsx
@@ -33,7 +33,11 @@ interface Item {
 
 const STORAGE_KEY = "SHOPPING_ITEMS";
 
-const ShoppingList: React.FC = () => {
+interface ShoppingListProps {
+  selectedModel: string;
+}
+
+const ShoppingList: React.FC<ShoppingListProps> = ({ selectedModel }) => {
   const [items, setItems] = useState<Item[]>([]);
   const [product, setProduct] = useState("");
   const [price, setPrice] = useState("");
@@ -161,7 +165,7 @@ const ShoppingList: React.FC = () => {
         const genAI = new GoogleGenAI({ apiKey: API_KEY });
 
         const result = await genAI.models.generateContent({
-          model: "gemini-2.5-flash-lite-preview-06-17",
+          model: selectedModel,
           contents: [
             {
               role: "user",

--- a/app/Wishlist.tsx
+++ b/app/Wishlist.tsx
@@ -29,7 +29,11 @@ interface Item {
 
 const STORAGE_KEY = "WISHLIST_ITEMS";
 
-const Wishlist: React.FC = () => {
+interface WishlistProps {
+  selectedModel: string;
+}
+
+const Wishlist: React.FC<WishlistProps> = ({ selectedModel }) => {
   const [items, setItems] = useState<Item[]>([]);
   const [product, setProduct] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -137,7 +141,7 @@ const Wishlist: React.FC = () => {
         const genAI = new GoogleGenAI({ apiKey: API_KEY });
 
         const result = await genAI.models.generateContent({
-          model: "gemini-2.5-flash-lite-preview-06-17",
+          model: selectedModel,
           contents: [
             {
               role: "user",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "^4.11.1",
     "react-native-web": "^0.20.0",
-    "react-native-webview": "^13.13.5",
-    "undefined": "\\"
+    "react-native-webview": "^13.13.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add ModelSelector component with three model options
- hook up selection storage in index screen
- pass selected model to ShoppingList, Wishlist and LLM chat
- show gear icon to open configuration modal
- update README and clean package.json

## Testing
- `npm install --legacy-peer-deps`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fe6a78778832f9e0a31e7d000fae7