### PR TITLE
Allow clearing Gemini API key in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The shopping list integrates with Google Gemini via the `@google/genai` SDK. You
 - Choose between different AI models via the new configuration menu.
 - Local data stored with `AsyncStorage` so your lists persist between sessions.
 - Optional **LLM Chat** screen for talking to the model.
+- Remove the stored Gemini API key from the settings screen.
 - Works on Android, iOS and the web through Expo.
 
 ## Setup
@@ -32,7 +33,7 @@ The shopping list integrates with Google Gemini via the `@google/genai` SDK. You
    ```bash
    npx expo start
    ```
-5. Use the settings button in the app header to choose between the available AI models.
+5. Use the settings button in the app header to choose between the available AI models or clear the stored API key.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The shopping list integrates with Google Gemini via the `@google/genai` SDK. You
 - Choose between different AI models via the new configuration menu.
 - Local data stored with `AsyncStorage` so your lists persist between sessions.
 - Optional **LLM Chat** screen for talking to the model.
-- Remove the stored Gemini API key from the settings screen.
+- Prompt for a Gemini API key on first launch and set or remove it from the settings screen.
 - Works on Android, iOS and the web through Expo.
 
 ## Setup
@@ -33,7 +33,7 @@ The shopping list integrates with Google Gemini via the `@google/genai` SDK. You
    ```bash
    npx expo start
    ```
-5. Use the settings button in the app header to choose between the available AI models or clear the stored API key.
+5. Use the settings button in the app header to choose between the available AI models or manage the stored API key.
 
 ## Running tests
 

--- a/app/ApiKeyModal.tsx
+++ b/app/ApiKeyModal.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+
+interface ApiKeyModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSave: (key: string) => void;
+  showError?: boolean;
+}
+
+const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ visible, onClose, onSave, showError }) => {
+  const [key, setKey] = useState('');
+
+  const handleSave = () => {
+    if (!key.trim()) return;
+    onSave(key.trim());
+    setKey('');
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.container}>
+          <Text style={styles.title}>Enter Gemini API Key</Text>
+          {showError && <Text style={styles.error}>A Gemini API key is required.</Text>}
+          <TextInput
+            style={styles.input}
+            value={key}
+            onChangeText={setKey}
+            placeholder="Gemini API Key"
+            placeholderTextColor="#888"
+            autoCapitalize="none"
+          />
+          <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+            <Text style={styles.saveText}>Save</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
+            <Text style={styles.cancelText}>Skip</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  container: {
+    width: '80%',
+    backgroundColor: '#242424',
+    borderRadius: 10,
+    padding: 20,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#fff',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  error: {
+    color: '#ff5252',
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  input: {
+    backgroundColor: '#333',
+    color: '#fff',
+    padding: 10,
+    borderRadius: 8,
+  },
+  saveButton: {
+    backgroundColor: '#1976D2',
+    padding: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  saveText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  cancelButton: {
+    marginTop: 10,
+    padding: 10,
+    alignItems: 'center',
+  },
+  cancelText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});
+
+export default ApiKeyModal;

--- a/app/LLMChat.tsx
+++ b/app/LLMChat.tsx
@@ -7,7 +7,7 @@ import {
   StyleSheet,
   ScrollView,
 } from "react-native";
-import { API_KEY } from "../config";
+import { getApiKey } from "../config";
 import { GoogleGenAI } from "@google/genai";
 import { supportsThinkingConfig } from "./aiUtils";
 
@@ -34,7 +34,7 @@ const LLMChat: React.FC<LLMChatProps> = ({ selectedModel }) => {
     setLoading(true);
 
     try {
-      const genAI = new GoogleGenAI({ apiKey: API_KEY });
+      const genAI = new GoogleGenAI({ apiKey: getApiKey() });
 
       const aiParams: any = {
         model: selectedModel,

--- a/app/LLMChat.tsx
+++ b/app/LLMChat.tsx
@@ -13,9 +13,10 @@ import { supportsThinkingConfig } from "./aiUtils";
 
 interface LLMChatProps {
   selectedModel: string;
+  onRequireApiKey: () => void;
 }
 
-const LLMChat: React.FC<LLMChatProps> = ({ selectedModel }) => {
+const LLMChat: React.FC<LLMChatProps> = ({ selectedModel, onRequireApiKey }) => {
   const [messages, setMessages] = useState<
     { role: "user" | "assistant"; content: string }[]
   >([]);
@@ -34,6 +35,10 @@ const LLMChat: React.FC<LLMChatProps> = ({ selectedModel }) => {
     setLoading(true);
 
     try {
+      if (!getApiKey()) {
+        onRequireApiKey();
+        return;
+      }
       const genAI = new GoogleGenAI({ apiKey: getApiKey() });
 
       const aiParams: any = {

--- a/app/SettingsModal.tsx
+++ b/app/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, View, Text, TouchableOpacity, StyleSheet, Switch } from 'react-native';
+import { Modal, View, Text, TouchableOpacity, StyleSheet, Switch, Alert } from 'react-native';
 import { MaterialIcons } from '@expo/vector-icons';
 
 interface SettingsModalProps {
@@ -10,6 +10,7 @@ interface SettingsModalProps {
   autoHideWishlistOnAdd: boolean;
   onToggleAutoHide: () => void;
   onClearApiKey: () => void;
+  onAddApiKey: () => void;
 }
 
 const MODELS = [
@@ -29,7 +30,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   autoHideWishlistOnAdd,
   onToggleAutoHide,
   onClearApiKey,
+  onAddApiKey,
 }) => {
+  const confirmRemove = () => {
+    Alert.alert('Remove Gemini API Key?', 'You can add it again later.', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Remove', style: 'destructive', onPress: onClearApiKey },
+    ]);
+  };
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <View style={styles.overlay}>
@@ -56,8 +64,14 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             />
           </View>
           <TouchableOpacity
+            style={styles.addKeyButton}
+            onPress={onAddApiKey}
+          >
+            <Text style={styles.addKeyText}>Set Gemini API Key</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
             style={styles.removeKeyButton}
-            onPress={onClearApiKey}
+            onPress={confirmRemove}
           >
             <Text style={styles.removeKeyText}>Remove Gemini API Key</Text>
           </TouchableOpacity>
@@ -118,8 +132,19 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 10,
   },
+  addKeyButton: {
+    backgroundColor: '#1976D2',
+    padding: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  addKeyText: {
+    color: '#fff',
+    fontSize: 16,
+  },
   removeKeyButton: {
-    backgroundColor: '#C62828',
+    backgroundColor: '#551111',
     padding: 10,
     borderRadius: 8,
     alignItems: 'center',

--- a/app/SettingsModal.tsx
+++ b/app/SettingsModal.tsx
@@ -9,6 +9,7 @@ interface SettingsModalProps {
   onSelectModel: (model: string) => void;
   autoHideWishlistOnAdd: boolean;
   onToggleAutoHide: () => void;
+  onClearApiKey: () => void;
 }
 
 const MODELS = [
@@ -27,6 +28,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onSelectModel,
   autoHideWishlistOnAdd,
   onToggleAutoHide,
+  onClearApiKey,
 }) => {
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
@@ -53,6 +55,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               onValueChange={onToggleAutoHide}
             />
           </View>
+          <TouchableOpacity
+            style={styles.removeKeyButton}
+            onPress={onClearApiKey}
+          >
+            <Text style={styles.removeKeyText}>Remove Gemini API Key</Text>
+          </TouchableOpacity>
           <TouchableOpacity style={styles.closeButton} onPress={onClose}>
             <Text style={styles.closeText}>Close</Text>
           </TouchableOpacity>
@@ -109,6 +117,17 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingVertical: 12,
     paddingHorizontal: 10,
+  },
+  removeKeyButton: {
+    backgroundColor: '#C62828',
+    padding: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  removeKeyText: {
+    color: '#fff',
+    fontSize: 16,
   },
   closeButton: {
     marginTop: 10,

--- a/app/ShoppingList.tsx
+++ b/app/ShoppingList.tsx
@@ -38,11 +38,13 @@ const WISHLIST_KEY = "WISHLIST_ITEMS";
 interface ShoppingListProps {
   selectedModel: string;
   autoHideWishlistOnAdd: boolean;
+  onRequireApiKey: () => void;
 }
 
 const ShoppingList: React.FC<ShoppingListProps> = ({
   selectedModel,
   autoHideWishlistOnAdd,
+  onRequireApiKey,
 }) => {
   const [items, setItems] = useState<Item[]>([]);
   const [product, setProduct] = useState("");
@@ -60,6 +62,10 @@ const ShoppingList: React.FC<ShoppingListProps> = ({
     wishlist: Item[],
     newItems: Item[]
   ): Promise<Item[]> => {
+    if (!getApiKey()) {
+      onRequireApiKey();
+      return wishlist;
+    }
     try {
       const genAI = new GoogleGenAI({ apiKey: getApiKey() });
       const prompt =
@@ -227,6 +233,10 @@ const ShoppingList: React.FC<ShoppingListProps> = ({
         const base64Audio = await FileSystem.readAsStringAsync(uri, {
           encoding: FileSystem.EncodingType.Base64,
         });
+        if (!getApiKey()) {
+          onRequireApiKey();
+          return;
+        }
         const genAI = new GoogleGenAI({ apiKey: getApiKey() });
 
         const aiParams: any = {

--- a/app/ShoppingList.tsx
+++ b/app/ShoppingList.tsx
@@ -18,7 +18,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { API_KEY } from "../config";
+import { getApiKey } from "../config";
 import { GoogleGenAI } from "@google/genai";
 import { supportsThinkingConfig } from "./aiUtils";
 
@@ -61,7 +61,7 @@ const ShoppingList: React.FC<ShoppingListProps> = ({
     newItems: Item[]
   ): Promise<Item[]> => {
     try {
-      const genAI = new GoogleGenAI({ apiKey: API_KEY });
+      const genAI = new GoogleGenAI({ apiKey: getApiKey() });
       const prompt =
         'You will receive a JSON array called WISHLIST and another array NEW_ITEMS. ' +
         'For every entry in NEW_ITEMS, if a semantically equivalent product exists in WISHLIST, ' +
@@ -227,7 +227,7 @@ const ShoppingList: React.FC<ShoppingListProps> = ({
         const base64Audio = await FileSystem.readAsStringAsync(uri, {
           encoding: FileSystem.EncodingType.Base64,
         });
-        const genAI = new GoogleGenAI({ apiKey: API_KEY });
+        const genAI = new GoogleGenAI({ apiKey: getApiKey() });
 
         const aiParams: any = {
           model: selectedModel,

--- a/app/Wishlist.tsx
+++ b/app/Wishlist.tsx
@@ -32,9 +32,10 @@ const STORAGE_KEY = "WISHLIST_ITEMS";
 
 interface WishlistProps {
   selectedModel: string;
+  onRequireApiKey: () => void;
 }
 
-const Wishlist: React.FC<WishlistProps> = ({ selectedModel }) => {
+const Wishlist: React.FC<WishlistProps> = ({ selectedModel, onRequireApiKey }) => {
   const [items, setItems] = useState<Item[]>([]);
   const [product, setProduct] = useState("");
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -138,7 +139,10 @@ const Wishlist: React.FC<WishlistProps> = ({ selectedModel }) => {
         const base64Audio = await FileSystem.readAsStringAsync(uri, {
           encoding: FileSystem.EncodingType.Base64,
         });
-
+        if (!getApiKey()) {
+          onRequireApiKey();
+          return;
+        }
         const genAI = new GoogleGenAI({ apiKey: getApiKey() });
 
         const aiParams: any = {

--- a/app/Wishlist.tsx
+++ b/app/Wishlist.tsx
@@ -17,7 +17,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { Audio } from "expo-av";
 import * as FileSystem from "expo-file-system";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { API_KEY } from "../config";
+import { getApiKey } from "../config";
 import { GoogleGenAI } from "@google/genai";
 import { supportsThinkingConfig } from "./aiUtils";
 
@@ -139,7 +139,7 @@ const Wishlist: React.FC<WishlistProps> = ({ selectedModel }) => {
           encoding: FileSystem.EncodingType.Base64,
         });
 
-        const genAI = new GoogleGenAI({ apiKey: API_KEY });
+        const genAI = new GoogleGenAI({ apiKey: getApiKey() });
 
         const aiParams: any = {
           model: selectedModel,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -20,8 +20,9 @@ import * as SplashScreen from "expo-splash-screen";
 import { MaterialIcons } from "@expo/vector-icons";
 import LLMChat from "./LLMChat";
 import SettingsModal from "./SettingsModal";
+import ApiKeyModal from "./ApiKeyModal";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { LLM_CHAT_ENABLED, initApiKey, clearApiKey } from "../config";
+import { getApiKey, LLM_CHAT_ENABLED, initApiKey, clearApiKey, setApiKey } from "../config";
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
@@ -35,6 +36,8 @@ export default function Index() {
   const [selectedModel, setSelectedModel] = useState<string>("gemini-2.5-flash-lite");
   const [configVisible, setConfigVisible] = useState(false);
   const [autoHideWishlistOnAdd, setAutoHideWishlistOnAdd] = useState(true);
+  const [apiKeyModalVisible, setApiKeyModalVisible] = useState(false);
+  const [apiKeyError, setApiKeyError] = useState(false);
 
   const hideKeyboard = () => {
     Keyboard.dismiss();
@@ -80,6 +83,19 @@ export default function Index() {
   const handleClearApiKey = async () => {
     await AsyncStorage.removeItem('GEMINI_API_KEY');
     clearApiKey();
+    setApiKeyModalVisible(true);
+  };
+
+  const handleSaveApiKey = async (key: string) => {
+    await AsyncStorage.setItem('GEMINI_API_KEY', key);
+    setApiKey(key);
+    setApiKeyError(false);
+    setApiKeyModalVisible(false);
+  };
+
+  const requireApiKey = () => {
+    setApiKeyError(true);
+    setApiKeyModalVisible(true);
   };
 
   const panResponder = useMemo(
@@ -116,6 +132,9 @@ export default function Index() {
       try {
         // Add any initialization logic here if needed
         await initApiKey();
+        if (!getApiKey()) {
+          setApiKeyModalVisible(true);
+        }
         await new Promise((resolve) => setTimeout(resolve, 100)); // Small delay to ensure proper initialization
       } catch (e) {
         console.warn(e);
@@ -225,11 +244,12 @@ export default function Index() {
         <ShoppingList
           selectedModel={selectedModel}
           autoHideWishlistOnAdd={autoHideWishlistOnAdd}
+          onRequireApiKey={requireApiKey}
         />
       ) : activeScreen === "wishlist" ? (
-        <Wishlist selectedModel={selectedModel} />
+        <Wishlist selectedModel={selectedModel} onRequireApiKey={requireApiKey} />
       ) : LLM_CHAT_ENABLED ? (
-        <LLMChat selectedModel={selectedModel} />
+        <LLMChat selectedModel={selectedModel} onRequireApiKey={requireApiKey} />
       ) : null}
       <SettingsModal
         visible={configVisible}
@@ -239,6 +259,16 @@ export default function Index() {
         autoHideWishlistOnAdd={autoHideWishlistOnAdd}
         onToggleAutoHide={toggleAutoHide}
         onClearApiKey={handleClearApiKey}
+        onAddApiKey={() => setApiKeyModalVisible(true)}
+      />
+      <ApiKeyModal
+        visible={apiKeyModalVisible}
+        onClose={() => {
+          setApiKeyError(false);
+          setApiKeyModalVisible(false);
+        }}
+        onSave={handleSaveApiKey}
+        showError={apiKeyError}
       />
     </SafeAreaView>
   );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -21,7 +21,7 @@ import { MaterialIcons } from "@expo/vector-icons";
 import LLMChat from "./LLMChat";
 import SettingsModal from "./SettingsModal";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { LLM_CHAT_ENABLED } from "../config";
+import { LLM_CHAT_ENABLED, initApiKey, clearApiKey } from "../config";
 
 // Keep the splash screen visible while we fetch resources
 SplashScreen.preventAutoHideAsync();
@@ -77,6 +77,11 @@ export default function Index() {
     await AsyncStorage.setItem('AUTO_HIDE_WISHLIST_ON_ADD', newValue.toString());
   };
 
+  const handleClearApiKey = async () => {
+    await AsyncStorage.removeItem('GEMINI_API_KEY');
+    clearApiKey();
+  };
+
   const panResponder = useMemo(
     () =>
       PanResponder.create({
@@ -110,6 +115,7 @@ export default function Index() {
     async function prepare() {
       try {
         // Add any initialization logic here if needed
+        await initApiKey();
         await new Promise((resolve) => setTimeout(resolve, 100)); // Small delay to ensure proper initialization
       } catch (e) {
         console.warn(e);
@@ -232,6 +238,7 @@ export default function Index() {
         onSelectModel={handleSelectModel}
         autoHideWishlistOnAdd={autoHideWishlistOnAdd}
         onToggleAutoHide={toggleAutoHide}
+        onClearApiKey={handleClearApiKey}
       />
     </SafeAreaView>
   );

--- a/config.ts
+++ b/config.ts
@@ -1,14 +1,28 @@
 // config.ts
 
-const ENV_GEMINI_API_KEY = process.env.EXPO_PUBLIC_GEMINI_API_KEY;
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const ENV_GEMINI_API_KEY = process.env.EXPO_PUBLIC_GEMINI_API_KEY || '';
 const LLM_CHAT_ENABLED_ENV = process.env.EXPO_PUBLIC_LLM_CHAT_ENABLED;
 
-if (!ENV_GEMINI_API_KEY) {
-  throw new Error('EXPO_PUBLIC_GEMINI_API_KEY is not defined in .env file');
-}
+let apiKey = ENV_GEMINI_API_KEY;
+
+export const getApiKey = () => apiKey;
+export const setApiKey = (key: string) => {
+  apiKey = key;
+};
+export const clearApiKey = () => {
+  apiKey = '';
+};
+
+export const initApiKey = async () => {
+  const stored = await AsyncStorage.getItem('GEMINI_API_KEY');
+  if (stored) {
+    apiKey = stored;
+  }
+};
 
 // Export all constants
-export const API_KEY = ENV_GEMINI_API_KEY;
 export const GEMINI_UPLOAD_API_URL = 'https://api.google.com/gemini/v2/upload'; // Replace with actual Gemini upload URL
 export const GEMINI_GENERATE_CONTENT_API_URL = 'https://api.google.com/gemini/v2/generateContent'; // Replace with actual Gemini generateContent URL
 


### PR DESCRIPTION
## Summary
- add runtime API key helpers in `config.ts`
- use `getApiKey` in all components
- load stored key on startup and allow clearing it
- expose a new button in settings modal to remove the Gemini API key
- document the new option in the README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_688015e29ab4832f8cd6ac45b9ec57c2